### PR TITLE
Solution for casper.test property is not available

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -21,6 +21,8 @@ var sendMessage = function() {
 var phantomCSSPath = paths.phantomcss;
 phantom.casperPath = paths.casper;
 phantom.injectJs(paths.bin.casper+s+'bootstrap.js');
+phantom.casperTest = true; // fix for CasperError: casper.test property is only available using the `casperjs test` command in Casper 1.1
+
 
 var casper = require('casper').create({
   viewportSize: viewportSize,


### PR DESCRIPTION
Found this solution when I got the same error after upgrading PhantomCss and Caperjs.
https://github.com/danbroooks/gulp-phantomcss/issues/4