### PR TITLE
Fix for issue#6 error Arguments to path.join must be strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "through2": "~2.0",
     "lodash": "~3.0",
     "phantomjs": "~1.9",
-    "bower": "~1.2"
+    "bower": "~1.3.8"
   },
   "devDependencies": {
     "mocha": "~2.2"


### PR DESCRIPTION
Update Bower version to fix postinstall error fixes #6 