### PR TITLE
Fix for issue #2 plus other options

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,72 @@
+{
+    "excludeFiles": ["node_modules/**", "bower_components/**"],
+
+    "requireCurlyBraces": [
+        "if",
+        "else",
+        "for",
+        "while",
+        "do",
+        "try",
+        "catch"
+    ],
+    "requireOperatorBeforeLineBreak": true,
+    "requireCamelCaseOrUpperCaseIdentifiers": true,
+    // "maximumLineLength": {
+    //   "value": 500,
+    //   "allowComments": true,
+    //   "allowRegex": true
+    // },
+    "validateIndentation": 2,
+    "validateQuoteMarks": "'",
+
+    "disallowMultipleLineStrings": true,
+    "disallowMixedSpacesAndTabs": true,
+    // "disallowTrailingWhitespace": true,
+    "disallowSpaceAfterPrefixUnaryOperators": true,
+    "disallowMultipleVarDecl": null,
+
+    "requireSpaceAfterKeywords": [
+      "if",
+      "else",
+      "for",
+      "while",
+      "do",
+      "switch",
+      "return",
+      "try",
+      "catch"
+    ],
+    "requireSpaceBeforeBinaryOperators": [
+        "=", "+=", "-=", "*=", "/=", "%=", "<<=", ">>=", ">>>=",
+        "&=", "|=", "^=", "+=",
+
+        "+", "-", "*", "/", "%", "<<", ">>", ">>>", "&",
+        "|", "^", "&&", "||", "===", "==", ">=",
+        "<=", "<", ">", "!=", "!=="
+    ],
+    "requireSpaceAfterBinaryOperators": true,
+    "requireSpacesInConditionalExpression": true,
+    "requireSpaceBeforeBlockStatements": true,
+    "requireLineFeedAtFileEnd": true,
+    "disallowSpacesInsideObjectBrackets": "all",
+    "disallowSpacesInsideArrayBrackets": "all",
+    "disallowSpacesInsideParentheses": true,
+
+    "validateJSDoc": {
+        "checkParamNames": true,
+        "requireParamTypes": true
+    },
+
+    "disallowMultipleLineBreaks": true,
+
+    "disallowCommaBeforeLineBreak": null,
+    "disallowDanglingUnderscores": null,
+    "disallowEmptyBlocks": null,
+    "disallowMultipleLineStrings": null,
+    "disallowTrailingComma": null,
+    "requireCommaBeforeLineBreak": null,
+    "requireDotNotation": null,
+    "requireMultipleVarDecl": null,
+    "requireParenthesesAroundIIFE": true
+}

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ casper.run();
 
 Options passed in to the plugin will be forwarded on to phantomcss, these include:
 
-#### options.screenshots
+#### options.screenshotRoot
 
 Type: `String`
 
@@ -47,13 +47,49 @@ Default: `'screenshots'`
 
 Directory where screenshot test fixtures are stored.
 
-#### options.results
+#### options.comparisonResultRoot
 
 Type: `String`
 
 Default: `'results'`
 
 Directory where source, diff and failure screenshots are stored.
+
+#### options.failedComparisonsRoot
+
+Type: `String`
+
+Default: `'failures'`
+
+Directory where failure screenshots are stored.
+
+#### options.mismatchTolerance
+
+Type: `Number`
+
+Default: `0.05`
+
+Increasing this value will decrease test coverage.
+
+Callbacks for your specific integration
+
+#### options.reportsRoot
+
+Type: `String or boolean`
+
+Default: `false`
+
+Directory where report JSON will be stored. If false, no JSON will be generated.
+
+#### options.breakOnError
+
+Type: `boolean`
+
+Default: `false`
+
+If true, gulp task will exit with error code if there are any failing tests.
+
+The following options passed in to the plugin will be forwarded on to casperjs, these include:
 
 #### options.viewportSize
 

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,10 @@
 {
-  "name": "gulp-phantomcss",
+  "name": "gulp-phantomcss2",
   "main": "index.js",
-  "version": "0.0.4",
-  "homepage": "https://github.com/danbroooks/gulp-phantomcss",
+  "version": "0.2.0",
+  "homepage": "https://github.com/pauljeter/gulp-phantomcss",
   "authors": [
-    "danbroooks <danger.dan_@hotmail.co.uk>"
+    "Paul Jeter <pauljeter@gmail.com>"
   ],
   "license": "MIT",
   "ignore": [

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "gulp-phantomcss",
-  "version": "0.1.0",
-  "homepage": "http://github.com/danbroooks/gulp-phantomcss",
-  "repository": "git://github.com/danbroooks/gulp-phantomcss.git",
-  "author": "Dan Brooks <danger.dan_@hotmail.co.uk>",
+  "name": "gulp-phantomcss2",
+  "version": "0.2.0",
+  "homepage": "http://github.com/pauljeter/gulp-phantomcss",
+  "repository": "git://github.com/pauljeter/gulp-phantomcss.git",
+  "author": "Paul Jeter <pauljeter@gmail.com>",
   "scripts": {
     "postinstall": "./node_modules/bower/bin/bower install phantomcss",
     "test": "mocha"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "bower": "~1.3.8"
   },
   "devDependencies": {
+    "gulp-util": "^3.0.6",
     "mocha": "~2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "through2": "~2.0",
     "lodash": "~3.0",
     "phantomjs": "~1.9",
-    "bower": "~1.3.8"
+    "bower": "~1.3.8",
+    "gulp-util": "^3.0.6"
   },
   "devDependencies": {
-    "gulp-util": "^3.0.6",
     "mocha": "~2.2"
   }
 }

--- a/src/gulp-phantomcss.js
+++ b/src/gulp-phantomcss.js
@@ -1,7 +1,8 @@
-
 var _ = require('lodash');
 var path = require('path');
 var through = require('through2');
+var gutil = require('gulp-util');
+var PluginError = gutil.PluginError;
 
 module.exports.configure = function(config) {
   this.paths = config.paths;
@@ -9,7 +10,7 @@ module.exports.configure = function(config) {
   return this;
 };
 
-module.exports.through = function(args){
+module.exports.through = function(args) {
   args = _.extend({
     screenshots: 'screenshots',
     results: 'results',
@@ -19,15 +20,31 @@ module.exports.through = function(args){
 
   args.paths = this.paths;
   var phantom = this.phantom;
+  var error = 0;
+
+  function endStream() {
+    if (args.breakOnError && error > 0) {
+      return this.emit('error', new PluginError(
+          'gulp-phantomcss', 'Some tests have failed.'
+      ));
+    }
+  }
 
   var stream = through.obj(function(file, enc, cb) {
+    if (file.isStream()) {
+      return this.emit('error', new PluginError(
+          'gulp-phantomcss',  'Streaming not supported'
+      ));
+    }
     args.test = path.resolve(file.path);
 
     phantom(args.paths.runnerjs, args)
-      .on('exit', function(){
-          cb(null, file);
+      .on('exit', function(fail) {
+        if (fail) {
+          error++;
+        }
+        cb(null, file);
       });
-  });
-
+  }, endStream);
   return stream;
 };

--- a/src/runner.js
+++ b/src/runner.js
@@ -12,17 +12,11 @@ var viewportSize = {
   height: args.viewportSize[1]
 };
 
-// Messages are sent to the parent by appending them to the tempfile
-var sendMessage = function() {
-  fs.write(args.tempFile, JSON.stringify(Array.prototype.slice.call(arguments)) + '\n', 'a');
-};
-
 // Initialise CasperJs
 var phantomCSSPath = paths.phantomcss;
 phantom.casperPath = paths.casper;
-phantom.injectJs(paths.bin.casper+s+'bootstrap.js');
+phantom.injectJs(paths.bin.casper + s + 'bootstrap.js');
 phantom.casperTest = true; // fix for CasperError: casper.test property is only available using the `casperjs test` command in Casper 1.1
-
 
 var casper = require('casper').create({
   viewportSize: viewportSize,
@@ -31,37 +25,82 @@ var casper = require('casper').create({
 });
 
 // Require and initialise PhantomCSS module
-var phantomcss = require(phantomCSSPath+s+'phantomcss.js');
+var phantomcss = require(phantomCSSPath + s + 'phantomcss.js');
+var addLabelToFailedImage = false;
+var rebase = false;
+var cleanupComparisonImages = false;
+var comparisonResultRoot;
+var mismatchTolerance = 0.05;
+var hideElements;
+var outputSettings;
+var now = new Date();
+var date = now.toDateString();
+var reportName = date.replace(/\s/g, "-");
+var fail = false; // Flag for failing tests
+
+// Create report file if reportsRoot set in options
+var sendResult = function(result, test) {
+  if (args.reportsRoot) {
+    fs.write(args.reportsRoot + s + reportName + '.txt', JSON.stringify(test) + ',');
+  }
+  console.log('[' + result + '] ' + JSON.stringify(test));
+};
+
+var onFail = function(test) {
+  sendResult('Fail', test);
+  fail = true;
+};
+
+var onPass = function(test) {
+  sendResult('Pass', test);
+};
+
+var onNewImage = function(test) {
+  console.log('[NEW IMAGE] ' + test.filename);
+};
+
+var onTimeout = function(test) {
+  console.log('[TIMEOUT] ' + test.filename);
+};
+
+var onComplete = function(allTests, noOfFails, noOfErrors) {};
 
 phantomcss.init({
-  screenshotRoot: args.screenshots,
-  failedComparisonsRoot: args.failures,
-  libraryRoot: phantomCSSPath, // Give absolute path, otherwise PhantomCSS fails
+  screenshotRoot: args.screenshots || args.screenshotRoot,
+  failedComparisonsRoot: args.failures || args.failedComparisonsRoot,
+  libraryRoot: args.libraryRoot || phantomCSSPath, // Give absolute path, otherwise PhantomCSS fails
+  addLabelToFailedImage: args.addLabelToFailedImage || addLabelToFailedImage,
+  comparisonResultRoot: args.comparisonResultRoot || args.results || comparisonResultRoot,
+  rebase: args.rebase || rebase,
+  cleanupComparisonImages: args.cleanupComparisonImages || cleanupComparisonImages,
+  mismatchTolerance: args.mismatchTolerance || mismatchTolerance,
+  outputSettings: args.outputSettings || outputSettings,
+  hideElements: args.hideElements || hideElements,
+  onPass: args.onPass || onPass,
+  onFail: args.onFail || onFail,
+  onTimeout: args.onTimeout || onTimeout,
+  onComplete: args.onComplete || onComplete
 
-  onFail: function(test) {
-    sendMessage('onFail', test);
-  },
-  onPass: function(test) {
-    sendMessage('onPass', test);
-  },
-  onTimeout: function(test) {
-    sendMessage('onTimeout', test);
-  },
-  onComplete: function(allTests, noOfFails, noOfErrors) {
-    sendMessage('onComplete', allTests, noOfFails, noOfErrors);
-  }
 });
+
+if (args.turnOffAnimations) {
+  phantomcss.turnOffAnimations();
+}
 
 // Run the test scenario
 require(args.test);
 
 // End tests and compare screenshots
 casper.then(function() {
-  phantomcss.compareSession();
-})
-.then(function() {
-  casper.test.done();
-})
-.run(function() {
-  phantom.exit();
-});
+    phantomcss.compareSession();
+  })
+  .then(function() {
+    casper.test.done();
+  })
+  .then(function() {
+    if (fail) {
+      phantom.exit(1);
+    } else {
+      phantom.exit(0);
+    }
+  });


### PR DESCRIPTION
Fixes #2  Test failure does not exit gulp task with correct status.
Add support for more setting more native PhantomCSS options.
Update README.md with updated options.
Left previous option names as fallback for backward compatability.