### PR TITLE
added windows path fix to phantomjs binary

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,4 @@
+{
+	"directory":"bower_components/",
+	"json": "bower.json"
+}

--- a/src/paths.js
+++ b/src/paths.js
@@ -3,10 +3,12 @@ var path = require('path');
 
 var root = path.join(__dirname, '..');
 
+var isWin = /^win/.test(process.platform);
+
 var paths = {
   root: root,
   runnerjs: path.join(root, 'src', 'runner.js'),
-  phantomjs: path.join(root, 'node_modules', '.bin', 'phantomjs'),
+  phantomjs: path.join(root, 'node_modules', '.bin', 'phantomjs'+(isWin ? ".cmd" : "")),
   phantomcss: path.join(root, 'bower_components', 'phantomcss')
 };
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -55,6 +55,7 @@ var onComplete = function(allTests, noOfFails, noOfErrors) {};
 phantomcss.init({
   screenshotRoot: args.screenshots || args.screenshotRoot, // Add ability to use original option from PhantomCSS
   failedComparisonsRoot: args.failures || args.failedComparisonsRoot, // Add ability to use original option from PhantomCSS
+  comparisonResultRoot: args.comparisonResultRoot,
   libraryRoot: phantomCSSPath, // Give absolute path, otherwise PhantomCSS fails
   onPass: args.onPass || onPass,
   onFail: args.onFail || onFail,


### PR DESCRIPTION
Was breaking on WIndows 10 because was missing ".cmd" at the end of the phantomjs binary path, so added a check for Windows and added it based on that condition. This may relate to issue #13, if they are Windows users.

Also added 'comparisonResultRoot' to list of params passed to phantomcss.init, because it had no effect otherwise.

Also added ".bowerrc" file because my parent project's ".bowerrc" path was affecting this module too. 