### PR TITLE
Switch option checking to respect passed options

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -53,8 +53,8 @@ var onTimeout = function(test) {
 var onComplete = function(allTests, noOfFails, noOfErrors) {};
 
 phantomcss.init({
-  screenshotRoot: args.screenshots || args.screenshotRoot, // Add ability to use original option from PhantomCSS
-  failedComparisonsRoot: args.failures || args.failedComparisonsRoot, // Add ability to use original option from PhantomCSS
+  screenshotRoot: args.screenshotRoot || args.screenshots, // Add ability to use original option from PhantomCSS
+  failedComparisonsRoot: args.failedComparisonsRoot || args.failures, // Add ability to use original option from PhantomCSS
   comparisonResultRoot: args.comparisonResultRoot,
   libraryRoot: phantomCSSPath, // Give absolute path, otherwise PhantomCSS fails
   onPass: args.onPass || onPass,


### PR DESCRIPTION
By default, gulp-phantomcss sets a backup screenshot option for
use. This will override the passed option variable. Flipping the checks,
now the passed option will be checked first before the fallback.