### PR TITLE
allow passing of command-line options to phantomJs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,83 +1,34 @@
 
-# gulp-phantomcss
+# gulp-phantomcss-options
 
-Run your phantomCSS tests with Gulp.
+Run your phantomCSS tests with Gulp.  
+This is a fork of gulp-phantomcss by Dan Brooks. It allows passing command line options to phantomJs.
 
 ## Installation
 Uninstall global node installations of casperjs and phantomjs
 
-`npm install gulp-phantomcss -D`
+`npm install gulp-phantomcss-options -D`
 
 ## Usage
 
 ```js
 var gulp = require('gulp');
 var phantomcss = require('gulp-phantomcss');
+var settings = require('../settings/phantomcss.json'); // path to a config file
 
 gulp.task('phantomcss', function (){
   gulp.src('./testsuite.js')
-    .pipe(phantomcss());
+    .pipe(phantomcss({
+            screenshotRoot: './phantomcss/screenshots',
+            failedComparisonsRoot: './phantomcss/failures',
+            comparisonResultRoot: './phantomcss/results',
+            screenshots: './phantomcss/base',
+            logLevel: 'error' // or: 'info', 'debug'
+          },
+          '--ignore-ssl-errors=true' // pass command line options
+        ));
 });
 ```
 
-Example ./testsuite.js :
-
-```js
-casper.
-  start( 'http://www.google.co.uk' ).
-  then(function(){
-    phantomcss.screenshot('#hplogo', 'google');
-  });
-
-casper.run();
-```
-
-### Options
-
-Options passed in to the plugin will be forwarded on to phantomcss, these include:
-
-#### options.screenshots
-
-Type: `String`
-
-Default: `'screenshots'`
-
-Directory where screenshot test fixtures are stored.
-
-#### options.comparisonResultRoot
-
-Type: `String`
-
-Default: `'results'`
-
-Directory where source, diff and failure screenshots are stored.
-
-#### options.breakOnError
-
-Type: `boolean`
-
-Default: `false`
-
-If true, gulp task will exit with error code if there are any failing tests.
-
-The following options passed in to the plugin will be forwarded on to casperjs, these include:
-
-#### options.viewportSize
-
-Type: `Array`
-
-Default: `[1280, 800]`
-
-Viewport size to run the test in. Useful for running tests for multiple window sizes.
-
-#### options.logLevel
-
-Type: `String`
-
-Default: `'error'`
-
-Log level for CasperJS, see [CasperJS: Logging](http://casperjs.readthedocs.org/en/latest/logging.html) for more information.
-
-## Testing
-
-Run tests with `npm test`
+## More info
+See https://github.com/danbroooks/gulp-phantomcss

--- a/index.js
+++ b/index.js
@@ -4,12 +4,16 @@ var _ = require('lodash');
 
 var paths = require('./src/paths.js');
 var phantom = require('./src/spawnPhantom.js');
-
-module.exports = function (opts) {
+/**
+ * module 'gulp-phantomcss'
+ * @param  {object} opts    Object of options passed to PhantomCSS: {screenshotRoot: '', ...}
+ * @param  {array}  flags 	Array of command-line options passed to PhantomJS: ['--debug=true', ...], see: http://phantomjs.org/api/command-line.html
+ */
+module.exports = function (opts, flags) {
   return require('./src/gulp-phantomcss.js')
     .configure({
       paths: paths,
       phantom: phantom(paths.phantomjs).spawn
     })
-    .through(opts);
+    .through(opts, flags);
 };

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "gulp-phantomcss",
-  "version": "0.3.0",
-  "description": "Gulp plugin for PhantomCSS",
+  "name": "gulp-phantomcss-options",
+  "version": "0.1.0",
+  "description": "Gulp plugin for PhantomCSS with command line options, fork from gulp-phantomcss",
   "main": "index.js",
-  "homepage": "http://github.com/danbroooks/gulp-phantomcss#readme",
+  "homepage": "https://github.com/kromakollision/gulp-phantomcss#readme",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/danbroooks/gulp-phantomcss.git"
+    "url": "git+https://github.com/kromakollision/gulp-phantomcss.git"
   },
-  "author": "Dan Brooks <danger.dan_@hotmail.co.uk>",
+  "author": "Koen Buckinx <koen.buckinx@gmail.com>",
   "scripts": {
     "test": "jasmine"
   },

--- a/src/gulp-phantomcss.js
+++ b/src/gulp-phantomcss.js
@@ -10,7 +10,7 @@ module.exports.configure = function (config) {
   return this;
 };
 
-module.exports.through = function (args) {
+module.exports.through = function (args, flags) {
 
   if (_.isString(args)) {
     args = { screenshots: args };
@@ -36,7 +36,7 @@ module.exports.through = function (args) {
 
     args.test = path.resolve(file.path);
 
-    phantom(args.paths.runnerjs, args)
+    phantom(args.paths.runnerjs, args, flags)
       .on('exit', function (fail) {
         if (fail) {
           error++;

--- a/src/spawnPhantom.js
+++ b/src/spawnPhantom.js
@@ -2,13 +2,13 @@ var spawn = require('child_process').spawn;
 
 module.exports = function (phantomPath) {
   return {
-    spawn: function (script, args) {
+    spawn: function (script, args, flags) {
       var opts = {
         stdio: 'inherit',
         cwd: process.cwd()
       };
-
-      return spawn(phantomPath, [script, JSON.stringify(args)], opts);
+      var flagsList = (typeof flags === 'string')? [flags]: (flags || []);
+      return spawn(phantomPath, flagsList.concat([script, JSON.stringify(args)]), opts);
     }
   };
 };


### PR DESCRIPTION
I added a parameter to be able to pass command-line options to PhantomJs, which as far as I could tell wasn't possible before.